### PR TITLE
Implement password hashing in AuthContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "bcryptjs": "^3.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -5022,6 +5023,15 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bfj": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "bcryptjs": "^3.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useState } from 'react';
+import bcrypt from 'bcryptjs';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  const signup = (email, password) => {
+    const salt = bcrypt.genSaltSync(10);
+    const hash = bcrypt.hashSync(password, salt);
+    localStorage.setItem('auth_user', JSON.stringify({ email, password: hash }));
+    setUser({ email });
+  };
+
+  const login = (email, password) => {
+    const stored = localStorage.getItem('auth_user');
+    if (!stored) return false;
+    const { email: storedEmail, password: storedHash } = JSON.parse(stored);
+    const isValid = storedEmail === email && bcrypt.compareSync(password, storedHash);
+    if (isValid) {
+      setUser({ email });
+    }
+    return isValid;
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, signup, login }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/contexts/AuthContext.test.js
+++ b/src/contexts/AuthContext.test.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, AuthContext } from './AuthContext';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('signup stores hashed password and login validates', () => {
+  const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+  const { result } = renderHook(() => React.useContext(AuthContext), { wrapper });
+
+  act(() => {
+    result.current.signup('test@example.com', 'secret');
+  });
+
+  const stored = JSON.parse(localStorage.getItem('auth_user'));
+  expect(stored.email).toBe('test@example.com');
+  expect(stored.password).not.toBe('secret');
+
+  let loginResult;
+  act(() => {
+    loginResult = result.current.login('test@example.com', 'secret');
+  });
+  expect(loginResult).toBe(true);
+});


### PR DESCRIPTION
## Summary
- create `AuthContext` and hash passwords with `bcryptjs`
- store password hash in localStorage and verify on login
- add `bcryptjs` dependency
- test `signup` and `login` logic

## Testing
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684154a27ce8832cbf48065f3a98930c