### PR TITLE
Fix hook order in Form

### DIFF
--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -1,9 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './Form.module.css';
 
 function Form({question, pass2next, addScore, wrongIndex})  {
   const [selectedAnswers, setSelectedAnswers] = useState([]);
   const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    // reset state whenever the question changes
+    setSelectedAnswers([]);
+    setSubmitted(false);
+  }, [question]);
+
   if (!question) {
     return <div>Loading...</div>; // Handle the case where question is undefined
   }


### PR DESCRIPTION
## Summary
- ensure `useEffect` runs before showing fallback loading UI
- reset form state when the question prop changes

## Testing
- `CI=true npm test --silent` *(fails: Unable to find element with the text /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6841549dcdbc832c9d28a947434f9a69